### PR TITLE
Separate docs ci workflow

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project -e '
+            using Pkg
+            Pkg.instantiate()
+            Pkg.add("Documenter")
+            Pkg.add("DataFrames")
+            Pkg.add("Latexify")'
+      - run: |
+          julia --project -e '
+            using Documenter: doctest
+            using QXZoo
+            doctest(QXZoo)'
+      - run: julia --project docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,28 +39,3 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - uses: julia-actions/julia-buildpkg@v1
-      - run: |
-          julia --project -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.add("Documenter")
-            Pkg.add("DataFrames")
-            Pkg.add("Latexify")'            
-      - run: |
-          julia --project -e '
-            using Documenter: doctest
-            using QXZoo
-            doctest(QXZoo)'
-      - run: julia --project docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXZoo"
 uuid = "f27fdc93-0c88-4b5a-91cb-e8275adac0f6"
 authors = ["QuantEx Team"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXZoo.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXZoo.jl/dev)
 [![Build Status](https://github.com/JuliaQX/QXZoo.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXZoo.jl/actions)
-[![Build Status](https://github.com/JuliaQX/QXZoo.jl/badges/master/pipeline.svg)](https://github.com/JuliaQX/QXZoo.jl/pipelines)
-[![Coverage](https://github.com/JuliaQX/QXZoo.jl/badges/master/coverage.svg)](https://github.com/JuliaQX/QXZoo.jl/commits/master)
 [![Coverage](https://codecov.io/gh/JuliaQX/QXZoo.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXZoo.jl)
 
 


### PR DESCRIPTION
### Summary

Separate ci workflow for docs into separate workflow

### Rationale

In separate workflow it can run for tags also so doc versions will appear for these.

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [ ] All discussions are resolved
- [ ] New code is covered by appropriate tests
- [ ] Tests are passing locally and on CI
- [ ] The documentation is consistent with changes
- [ ] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [ ] Notebooks/examples not covered by unittests have been tested and updated as required
- [ ] The feature branch is up-to-date with the master branch (rebase if behind)
- [ ] Incremented the version string in Project.toml file
